### PR TITLE
SSS: Simple Sane Savings via sell order 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Example: Given Initial buy of 500 NCM at price of 0.001, rake = 0.5, cycleMultip
 the command node app.js --sell-order -c NCM -f 0.001 will produce the following sells:
 
 SELL 250 NCM @ 0.002
+
 SELL 125 NCM @ 0.004
+
 SELL 62.5 NCM @ 0.008
+
 SELL 31.25 NCM @ 0.016

--- a/README.md
+++ b/README.md
@@ -58,3 +58,19 @@ npm start -- --restore-orders backups/backup-<date>.json  # This recreates all l
 
 There is also a shell script, `util/csv-to-json.sh`, which may be useful for importing order lists from CSV files (e.g.
 if you kept a manual backup of your open orders before Bittrex cancelled them).
+
+### Sell Orders
+
+The tool also has the ability to create new sell orders following a generic plan
+```
+node app.js --sell-order -c COIN_NAME -f INITIAL_BUY_IN_BTC
+```
+
+Example: Given Initial buy of 500 NCM at price of 0.001, rake = 0.5, cycleMultiplier: 2, numberOfCycles:4
+
+the command node app.js --sell-order -c NCM -f 0.001 will produce the following sells:
+
+SELL 250 NCM @ 0.002
+SELL 125 NCM @ 0.004
+SELL 62.5 NCM @ 0.008
+SELL 31.25 NCM @ 0.016

--- a/config.json
+++ b/config.json
@@ -25,7 +25,7 @@
   "replaceAllOrders": false,
 
   // concurrentTasks: How many API-related "tasks" to run concurrently
-  "concurrentTasks": 4
+  "concurrentTasks": 4,
 
 
   //** End additional settings, that you shouldn't need to modify ***
@@ -44,5 +44,4 @@
 
   //The sell price from initial investment. ex: cycleMultiplier: 2, rake: 0.5 sell half at double
   "cycleMultiplier": 2
-}
 }

--- a/config.json
+++ b/config.json
@@ -26,4 +26,23 @@
 
   // concurrentTasks: How many API-related "tasks" to run concurrently
   "concurrentTasks": 4
+
+
+  //** End additional settings, that you shouldn't need to modify ***
+
+  //** Additional settings, you MAY want to modify ***
+
+  //SANE AND SIMPLE SAVINGS PLAN:
+  //original post: https://bitcointalk.org/index.php?topic=345065.0
+  //website: https://bitcoinsavingsplan.com
+
+  //The total amount to sell given as a decimal percentage 50% = 0.5
+  "rake": 0.5,
+
+  //Total number of sells
+  "numberOfCycles": 10,
+
+  //The sell price from initial investment. ex: cycleMultiplier: 2, rake: 0.5 sell half at double
+  "cycleMultiplier": 2
+}
 }


### PR DESCRIPTION
This pull requests adds the parameters: rake, cycleMultiplier, and numberOfCycles to the config file to allow the following Simple Sane Savings(SSS): https://bitcoinsavingsplan.com adapted for altcoin trading. It is defaulted to selling 50% on every 2x multiplier from initial buy price for a total of 10 cycles. These parameters can be tweaked by the user by changing them in the config.json

It also adds the command sell-order to app.js file in addition to the sell logic. I have tested this code myself and it works. Please review