### PR TITLE
SSS: Simple Sane Savings via sell order

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,22 @@ npm start -- --restore-orders backups/backup-<date>.json  # This recreates all l
 
 There is also a shell script, `util/csv-to-json.sh`, which may be useful for importing order lists from CSV files (e.g.
 if you kept a manual backup of your open orders before Bittrex cancelled them).
+
+### Sell Orders
+
+The tool also has the ability to create new sell orders following a generic plan
+```
+node app.js --sell-order -c COIN_NAME -f INITIAL_BUY_IN_BTC
+```
+
+Example: Given Initial buy of 500 NCM at price of 0.001, rake = 0.5, cycleMultiplier: 2, numberOfCycles:4
+
+node app.js --sell-order -c NCM -f 0.001 will produce the following sells:
+
+SELL 250 NCM @ 0.002
+
+SELL 125 NCM @ 0.004
+
+SELL 62.5 NCM @ 0.008
+
+SELL 31.25 NCM @ 0.016

--- a/app.js
+++ b/app.js
@@ -187,31 +187,42 @@ if(program.sellOrder && program.float && program.coin){
       logger.info(' program.float: %j', Math.round(program.float,-4))
       logger.info(' program.coin: %j', program.coin);
 
-      getBalance(function(d) {
-        console.log(d);
+      getBalance(program.coin, function(data) {
+          console.log(data);
 
-        var tempQty    = d.Available;
-        var tempSell   = program.float;
-        var pair       = 'BTC-'+ program.coin
-        var i          = 1;
-        logger.info("program.float: %j", program.float);
+          var tempQty    = data.Available;
+          var totQty     = data.Available;
+          var tempSell   = program.float;
+          var pair       = 'BTC-'+ program.coin
+          var i          = 1;
+          logger.info("program.float: %f", program.float);
 
-        for(var i = 1; i <= config.numberOfCycles; i++){
+          var mat = [];
+          for(var i = 1; i <= config.numberOfCycles; i++) mat.push(i);
 
-            tempQty  = tempQty  - tempQty * config.rake;
+
+          async.forEach( Object.keys(mat) , function(callback){
+            tempQty  = totQty * config.rake;
+            totQty   = totQty - tempQty;
             tempSell = tempSell * config.cycleMultiplier;
-
             logger.info("Sell %f %j for %f each", roundDown(tempQty, 7) ,program.coin,tempSell);
-  	    limitSellOrder(pair, roundDown(tempQty,7) ,tempSell, function(d){
-                console.log(d);
+            limitSellOrder(pair, roundDown(tempQty,7) ,tempSell, function(d){
+              console.log(d);
+            });
+
+
+          },function(err) {
+              if(err) throw err
+              console.log("calling callback");
+              callback();
           });
-        }
-      });
+        });
     }
 
 
-function getBalance(callback){
-  bittrex.getbalance({ currency : program.coin },function(err, data){
+
+function getBalance(coin, callback){
+  bittrex.getbalance({ currency : coin },function(err, data){
     if (err) {
       return console.error(err);
     }

--- a/app.js
+++ b/app.js
@@ -202,12 +202,13 @@ if(program.sellOrder && program.float && program.coin){
             tempSell = tempSell * config.cycleMultiplier;
 
             logger.info("Sell %f %j for %f each", roundDown(tempQty, 7) ,program.coin,tempSell);
-            limitSellOrder(pair, roundDown(tempQty,7) ,tempSell, function(d){
+  	    limitSellOrder(pair, roundDown(tempQty,7) ,tempSell, function(d){
                 console.log(d);
           });
         }
       });
     }
+
 
 function getBalance(callback){
   bittrex.getbalance({ currency : program.coin },function(err, data){
@@ -229,7 +230,12 @@ function limitSellOrder(mPair,qty, rate, callback){
        Target: 0, // used in conjunction with ConditionType
      }, function( err, data ) {
        if(err){
-           return console.log("duhh!, limit order not placed");
+	if(err.message == "MIN_TRADE_REQUIREMENT_NOT_MET") return console.log(err);
+        //try again
+	setTimeout(limitSellOrder(mPair,qty, rate, function(d){
+             console.log(d)
+           }),500);
+           return console.log(err)
         }
        callback( data );
   });

--- a/config.json
+++ b/config.json
@@ -4,8 +4,8 @@
   "credentials": {
     /* Create a new API key on Bittrex and give it "read info" and "trade limit" permissions ONLY.
      * Then configure the API key and secret here: */
-    "key": "",
-    "secret": ""
+     "key": "",
+     "secret": ""
   },
 
 
@@ -25,5 +25,22 @@
   "replaceAllOrders": false,
 
   // concurrentTasks: How many API-related "tasks" to run concurrently
-  "concurrentTasks": 1
+  "concurrentTasks": 1,
+
+  //** End additional settings, that you shouldn't need to modify ***
+
+  //** Additional settings, you MAY want to modify ***
+
+  //SANE AND SIMPLE SAVINGS PLAN:
+  //original post: https://bitcointalk.org/index.php?topic=345065.0
+  //website: https://bitcoinsavingsplan.com
+
+  //The total amount to sell given as a decimal percentage 50% = 0.5
+  "rake": 0.5,
+
+  //Total number of sells
+  "numberOfCycles": 10,
+
+  //The sell price from initial investment. ex: cycleMultiplier: 2, rake: 0.5 sell half at double
+  "cycleMultiplier": 2
 }


### PR DESCRIPTION
This pull requests adds the parameters: rake, cycleMultiplier, and numberOfCycles to the config file to allow the following Simple Sane Savings(SSS): https://bitcoinsavingsplan.com adapted for altcoin trading. It is defaulted to selling 50% on every 2x multiplier from initial buy price for a total of 10 cycles. These parameters can be tweaked by the user by changing them in the config.json